### PR TITLE
fix: lock foundry to  --version nightly-f625d0fa7c51e65b4bf1e8f7931cd…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:21.6.2-bookworm as build
 
 ENV FOUNDRY_DIR /usr/local
 RUN curl -L https://foundry.paradigm.xyz | bash && \
-  /usr/local/bin/foundryup
+  /usr/local/bin/foundryup --version nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
 
 WORKDIR /
 


### PR DESCRIPTION
…1c6e2e285e9